### PR TITLE
Update CustomCalendarView.java

### DIFF
--- a/library/src/com/imanoweb/calendarview/CustomCalendarView.java
+++ b/library/src/com/imanoweb/calendarview/CustomCalendarView.java
@@ -168,7 +168,9 @@ public class CustomCalendarView extends LinearLayout {
         final String[] weekDaysArray = new DateFormatSymbols(locale).getShortWeekdays();
         for (int i = 1; i < weekDaysArray.length; i++) {
             dayOfTheWeekString = weekDaysArray[i];
-            dayOfTheWeekString = dayOfTheWeekString.substring(0, 3).toUpperCase();
+            if(dayOfTheWeekString.length() > 3){
+                dayOfTheWeekString = dayOfTheWeekString.substring(0, 3).toUpperCase();
+            }
             dayOfWeek = (TextView) view.findViewWithTag(DAY_OF_WEEK + getWeekIndex(i, currentCalendar));
             dayOfWeek.setText(dayOfTheWeekString);
             dayOfWeek.setTextColor(dayOfWeekTextColor);


### PR DESCRIPTION
initializeWeekLayout() method modified to handle the shorter day names than 3 chars.
